### PR TITLE
add docker compose file for portainer

### DIFF
--- a/docker-compose-portainer.yml
+++ b/docker-compose-portainer.yml
@@ -1,0 +1,16 @@
+services:
+  portainer:
+    image: portainer/portainer-ce:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./conf:/conf
+    ports:
+      - 9000:9000
+    deploy:
+      resources:
+        limits:
+          cpus: '0.08'
+          memory: 50M
+        reservations:
+          cpus: '0.05'
+          memory: 50M


### PR DESCRIPTION
Add docker compose file for running portainer image. In the future we can move other infrastructral services, such as traefik, grafana, etc. here.