### PR TITLE
Port Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-# infrastructure
-Main infrastructure configuration of the server to manage the deployment of vserver.
+# Infrastructure
+
+Main infrastructure configuration of the server to manage the deployment of server.
+
+For the list of open ports, see [ports.md](./ports.md)

--- a/ports.md
+++ b/ports.md
@@ -1,0 +1,18 @@
+# Port Management
+
+The current open ports are listed below. The services that run on these ports are visible through `.env` file.
+
+| TCP PORT | UDP PORT |
+|----------|----------|
+|   80     |  5680    |
+|   8080   |  5681    |
+|   8081   |  5682    |
+|   8082   |  5683    |
+|   8083   |  5684    |
+|   8084   |  5685    |
+|   8085   |  5686    |
+|   8086   |  5687    |
+|   8087   |  5688    |
+|   8088   |  5689    |
+|   8089   |  -       |
+|   5685   |  -       |


### PR DESCRIPTION
Moving from https://github.com/eclipse-thingweb/thingweb/tree/main/server but now the used services are tracked via `.env`